### PR TITLE
Allows polling of InputAction in Fixed Step.

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -1156,9 +1156,10 @@ namespace UnityEngine.InputSystem
             var state = GetOrCreateActionMap().m_State;
             if (state != null)
             {
+                // (PON): Modified so we can poll this in FixedUpdate(). See InputSystem.SetLastPollingUpdate().
                 var actionStatePtr = &state.actionStates[m_ActionIndexInState];
-                var currentUpdateStep = InputUpdate.s_UpdateStepCount;
-                return actionStatePtr->pressedInUpdate == currentUpdateStep && currentUpdateStep != default;
+                var lastPollingUpdate = InputSystem.s_Manager.lastPollingUpdate ?? InputState.updateCount - 1;
+                return actionStatePtr->pressedInUpdate > lastPollingUpdate;
             }
 
             return false;
@@ -1205,9 +1206,10 @@ namespace UnityEngine.InputSystem
             var state = GetOrCreateActionMap().m_State;
             if (state != null)
             {
+                // (PON): Modified so we can poll this in FixedUpdate(). See InputSystem.SetLastPollingUpdate().
                 var actionStatePtr = &state.actionStates[m_ActionIndexInState];
-                var currentUpdateStep = InputUpdate.s_UpdateStepCount;
-                return actionStatePtr->releasedInUpdate == currentUpdateStep && currentUpdateStep != default;
+                var lastPollingUpdate = InputSystem.s_Manager.lastPollingUpdate ?? InputState.updateCount - 1;
+                return actionStatePtr->releasedInUpdate > lastPollingUpdate;
             }
 
             return false;
@@ -1263,9 +1265,10 @@ namespace UnityEngine.InputSystem
 
             if (state != null)
             {
+                // (PON): Modified so we can poll this in FixedUpdate(). See InputSystem.SetLastPollingUpdate().
                 var actionStatePtr = &state.actionStates[m_ActionIndexInState];
-                var currentUpdateStep = InputUpdate.s_UpdateStepCount;
-                return actionStatePtr->lastPerformedInUpdate == currentUpdateStep && currentUpdateStep != default;
+                var lastPollingUpdate = InputSystem.s_Manager.lastPollingUpdate ?? InputState.updateCount - 1;
+                return actionStatePtr->lastPerformedInUpdate > lastPollingUpdate;
             }
 
             return false;

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.CompilerServices;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.Scripting;
@@ -99,10 +98,8 @@ namespace UnityEngine.InputSystem.Controls
         // (PON): We've deprecated these. Use InputAction.WasPressedThisFrame() instead.
         // This is because we poll on several schedules (Update and FixedUpdate), which is more complex than 
         // simply checking the previous frame buffer. (Previous Frame Buffer only contains previous render frame)
-        [Obsolete("PON: We've deprecated these. Use InputAction.WasPressedThisFrame() instead.", true)]
-        public bool wasPressedThisFrame => device.wasUpdatedThisFrame && IsValueConsideredPressed(value) && !IsValueConsideredPressed(ReadValueFromPreviousFrame());
-        [Obsolete("PON: We've deprecated these. Use InputAction.WasPressedThisFrame() instead.", true)]
-        public bool wasReleasedThisFrame => device.wasUpdatedThisFrame && !IsValueConsideredPressed(value) && IsValueConsideredPressed(ReadValueFromPreviousFrame());
+        // public bool wasPressedThisFrame => device.wasUpdatedThisFrame && IsValueConsideredPressed(value) && !IsValueConsideredPressed(ReadValueFromPreviousFrame());
+        // public bool wasReleasedThisFrame => device.wasUpdatedThisFrame && !IsValueConsideredPressed(value) && IsValueConsideredPressed(ReadValueFromPreviousFrame());
 
         // We make the current global default button press point available as a static so that we don't have to
         // constantly make the hop from InputSystem.settings -> InputManager.m_Settings -> defaultButtonPressPoint.

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.Scripting;
@@ -98,8 +99,10 @@ namespace UnityEngine.InputSystem.Controls
         // (PON): We've deprecated these. Use InputAction.WasPressedThisFrame() instead.
         // This is because we poll on several schedules (Update and FixedUpdate), which is more complex than 
         // simply checking the previous frame buffer. (Previous Frame Buffer only contains previous render frame)
-        // public bool wasPressedThisFrame => device.wasUpdatedThisFrame && IsValueConsideredPressed(value) && !IsValueConsideredPressed(ReadValueFromPreviousFrame());
-        // public bool wasReleasedThisFrame => device.wasUpdatedThisFrame && !IsValueConsideredPressed(value) && IsValueConsideredPressed(ReadValueFromPreviousFrame());
+        [Obsolete("PON: We've deprecated these. Use InputAction.WasPressedThisFrame() instead.", true)]
+        public bool wasPressedThisFrame => device.wasUpdatedThisFrame && IsValueConsideredPressed(value) && !IsValueConsideredPressed(ReadValueFromPreviousFrame());
+        [Obsolete("PON: We've deprecated these. Use InputAction.WasPressedThisFrame() instead.", true)]
+        public bool wasReleasedThisFrame => device.wasUpdatedThisFrame && !IsValueConsideredPressed(value) && IsValueConsideredPressed(ReadValueFromPreviousFrame());
 
         // We make the current global default button press point available as a static so that we don't have to
         // constantly make the hop from InputSystem.settings -> InputManager.m_Settings -> defaultButtonPressPoint.

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
@@ -95,9 +95,11 @@ namespace UnityEngine.InputSystem.Controls
         /// <seealso cref="InputSystem.onAnyButtonPress"/>
         public bool isPressed => IsValueConsideredPressed(value);
 
-        public bool wasPressedThisFrame => device.wasUpdatedThisFrame && IsValueConsideredPressed(value) && !IsValueConsideredPressed(ReadValueFromPreviousFrame());
-
-        public bool wasReleasedThisFrame => device.wasUpdatedThisFrame && !IsValueConsideredPressed(value) && IsValueConsideredPressed(ReadValueFromPreviousFrame());
+        // (PON): We've deprecated these. Use InputAction.WasPressedThisFrame() instead.
+        // This is because we poll on several schedules (Update and FixedUpdate), which is more complex than 
+        // simply checking the previous frame buffer. (Previous Frame Buffer only contains previous render frame)
+        // public bool wasPressedThisFrame => device.wasUpdatedThisFrame && IsValueConsideredPressed(value) && !IsValueConsideredPressed(ReadValueFromPreviousFrame());
+        // public bool wasReleasedThisFrame => device.wasUpdatedThisFrame && !IsValueConsideredPressed(value) && IsValueConsideredPressed(ReadValueFromPreviousFrame());
 
         // We make the current global default button press point available as a static so that we don't have to
         // constantly make the hop from InputSystem.settings -> InputManager.m_Settings -> defaultButtonPressPoint.

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -1276,18 +1276,20 @@ namespace UnityEngine.InputSystem
         // (PON): Deprecated as a part of our input polling tweak. This reads the value from the previous 'input frame'
         // which is the last time input was updated, and could be in either the Render or FixedUpdate. Using this is 
         // liable to cause lost inputs or inaccuracies.
+        //
         ////REVIEW: is 'frame' really the best wording here?
         // /// <summary>
         // /// Get the control's value from the previous frame (<see cref="InputControl.previousFrameStatePtr"/>).
         // /// </summary>
         // /// <returns>The control's value in the previous frame.</returns>
-        // public TValue ReadValueFromPreviousFrame()
-        // {
-        //     unsafe
-        //     {
-        //         return ReadValueFromState(previousFrameStatePtr);
-        //     }
-        // }
+        [Obsolete("PON: We've deprecated these. Use InputAction.WasPressedThisFrame() instead.", true)]
+        public TValue ReadValueFromPreviousFrame()
+        {
+            unsafe
+            {
+                return ReadValueFromState(previousFrameStatePtr);
+            }
+        }
 
         /// <summary>
         /// Get the control's default value.

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -1276,20 +1276,18 @@ namespace UnityEngine.InputSystem
         // (PON): Deprecated as a part of our input polling tweak. This reads the value from the previous 'input frame'
         // which is the last time input was updated, and could be in either the Render or FixedUpdate. Using this is 
         // liable to cause lost inputs or inaccuracies.
-        //
         ////REVIEW: is 'frame' really the best wording here?
         // /// <summary>
         // /// Get the control's value from the previous frame (<see cref="InputControl.previousFrameStatePtr"/>).
         // /// </summary>
         // /// <returns>The control's value in the previous frame.</returns>
-        [Obsolete("PON: We've deprecated these. Use InputAction.WasPressedThisFrame() instead.", true)]
-        public TValue ReadValueFromPreviousFrame()
-        {
-            unsafe
-            {
-                return ReadValueFromState(previousFrameStatePtr);
-            }
-        }
+        // public TValue ReadValueFromPreviousFrame()
+        // {
+        //     unsafe
+        //     {
+        //         return ReadValueFromState(previousFrameStatePtr);
+        //     }
+        // }
 
         /// <summary>
         /// Get the control's default value.

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -1273,18 +1273,21 @@ namespace UnityEngine.InputSystem
             return value;
         }
 
+        // (PON): Deprecated as a part of our input polling tweak. This reads the value from the previous 'input frame'
+        // which is the last time input was updated, and could be in either the Render or FixedUpdate. Using this is 
+        // liable to cause lost inputs or inaccuracies.
         ////REVIEW: is 'frame' really the best wording here?
-        /// <summary>
-        /// Get the control's value from the previous frame (<see cref="InputControl.previousFrameStatePtr"/>).
-        /// </summary>
-        /// <returns>The control's value in the previous frame.</returns>
-        public TValue ReadValueFromPreviousFrame()
-        {
-            unsafe
-            {
-                return ReadValueFromState(previousFrameStatePtr);
-            }
-        }
+        // /// <summary>
+        // /// Get the control's value from the previous frame (<see cref="InputControl.previousFrameStatePtr"/>).
+        // /// </summary>
+        // /// <returns>The control's value in the previous frame.</returns>
+        // public TValue ReadValueFromPreviousFrame()
+        // {
+        //     unsafe
+        //     {
+        //         return ReadValueFromState(previousFrameStatePtr);
+        //     }
+        // }
 
         /// <summary>
         /// Get the control's default value.

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -349,7 +349,10 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         public double lastUpdateTime => m_LastUpdateTimeInternal - InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup;
 
-        public bool wasUpdatedThisFrame => m_CurrentUpdateStepCount == InputUpdate.s_UpdateStepCount;
+        // (PON): Modified so we can poll this in FixedUpdate(). See InputSystem.SetLastPollingUpdate().
+        public bool wasUpdatedThisFrame => InputSystem.s_Manager.lastPollingUpdate.HasValue
+            ? m_CurrentUpdateStepCount > InputSystem.s_Manager.lastPollingUpdate.Value
+            : m_CurrentUpdateStepCount == InputUpdate.s_UpdateStepCount;
 
         /// <summary>
         /// A flattened list of controls that make up the device.

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1982,6 +1982,15 @@ namespace UnityEngine.InputSystem
         private InputDeviceExecuteCommandDelegate m_DeviceFindExecuteCommandDelegate;
         private int m_DeviceFindExecuteCommandDeviceId;
 
+        /// <summary>
+        /// (PON): The updateCount of the last time we polled for changes. Used to define what a 'frame' is in
+        /// ButtonControl.wasPressedThisFrame, InputAction.WasPressedThisFrame(), etc. This can be set manually
+        /// if you have several schedules you would like to poll buttons on, such as both the FixedUpdate and Update().
+        /// If not set, defaults to the immediately previous update. 
+        /// </summary>
+        /// <seealso cref="InputSystem.SetLastPollingUpdate"/>
+        public uint? lastPollingUpdate;
+        
         #if UNITY_ANALYTICS || UNITY_EDITOR
         private bool m_HaveSentStartupAnalytics;
         #endif

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using UnityEngine.InputSystem.Haptics;
 using Unity.Collections.LowLevel.Unsafe;
+using UnityEngine.Assertions;
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
@@ -3207,6 +3208,33 @@ namespace UnityEngine.InputSystem
 
         internal static InputManager s_Manager;
         internal static InputRemoting s_Remote;
+        
+        // (PON): Added to support polling input in both Update and FixedUpdate.
+        /// <summary>
+        /// The updateCount of the last time we polled for changes. Used to define what a 'frame' is in
+        /// InputAction.WasPressedThisFrame(), etc. This can be used if you have several schedules you would
+        /// like to poll buttons on, such as both the FixedUpdate() and Update().
+        /// 
+        /// The intention is to run this before each polling (ie. Update and FixedUpdate) to control which button presses
+        /// are considered 'happened since the last frame'. Defaults to the immediately previous update step, which makes
+        /// the 'frame' a single InputSystem.Update().
+        /// </summary>
+        public static void SetLastPollingUpdate(uint lastPollingUpdate)
+        {
+            Assert.IsTrue(s_Manager.lastPollingUpdate == null, "A last polling update was already set, are you missing a call to UnsetLastPollingUpdate()?");
+            s_Manager.lastPollingUpdate = lastPollingUpdate;
+        }
+
+        // (PON): Added to support polling input in both Update and FixedUpdate.
+        /// <summary>
+        /// Clears the value set by <see cref="SetLastPollingUpdate"/>. This returns the WasPressedThisFrame() behavior
+        /// to the default (ie. based InputSystem.Update calls).
+        /// </summary>
+        public static void ClearLastPollingUpdate()
+        {
+            Assert.IsTrue(s_Manager.lastPollingUpdate != null, "A last polling update wasn't set, are you missing a call to StLastPollingUpdate()?");
+            s_Manager.lastPollingUpdate = null;
+        }
 
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
         internal static RemoteInputPlayerConnection s_RemoteConnection;

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -219,6 +219,7 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
+        // Note(PON): The timeline input events are on. realTimeSinceStartup, since the start of the player. 
         public double currentTime => NativeInputSystem.currentTime;
 
         ////REVIEW: this applies the offset, currentTime doesn't


### PR DESCRIPTION
This adds support for customizing the range of input updates the InputSystem considers to be "This Frame". Summary:
- Call `InputSystem.SetLastPollingUpdate(inputStepCount);` where `inputStepCount` is the values of `InputState.updateCount` when we you last polled. `WasPressedThisFrame()` will now consider all presses since `inputStepCount` to be this frame.
- Call `InputSystem.ClearLastPollingUpdate()` to return polling to default behavior.

Pragmatically, we can use this in our Fixed Step to read from `InputAction.WasPressedThisFrame()` in the fixed step, even if Input is updated on a different schedule.

Why this works:

InputActions already stores the input `updateCount` when it was last pressed. This just changes the logic around the checks to specify a range of valid updateCounts that are considered 'this frame' rather than just checking `pressedInUpdate == currentUpdateStep`.

Shockingly, I believe this is the **only** change necessary to enable input actions on the FixedUpdate. This is a bit subtle! Input Actions have a lot of state in them (stored in `InputActionState.cs`):
 - The Started/Performed/Cancelled state machine.
 - Interaction State (the multi-tap interactors)

I expected to need to mirror all of this state for the FixedUpdate. Essentially keeping a separate action state for the Update and FixedUpdate, and pumping them both. However, all of this state exists on a completely different timeline already: input events are their own timeline based on `realTimeSinceStartup`, which is indifferent to the Update frames. This is necessary because input events can be queued at any time, and even counteract themselves all before InputSystem.Update runs.

It's another case of the InputSystem just being well designed. Really there's only a few places that interact with the concept of a 'frame'. I've modified the ones we use, and for now just  deprecated the others (they were unused anyway). I've commented them out, because we want them to throw errors if another package happens to use them (although it's fairly rare, the values are quite low level).